### PR TITLE
Update to actions/cache@v4

### DIFF
--- a/.github/workflows/api-check.yaml
+++ b/.github/workflows/api-check.yaml
@@ -22,7 +22,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -51,7 +51,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/web-check.yaml
+++ b/.github/workflows/web-check.yaml
@@ -23,7 +23,7 @@ jobs:
         run: cd web && npm ci
 
       - name: NPM Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('web/package.json') }}


### PR DESCRIPTION
Required by https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/